### PR TITLE
Replace direct reference to style.css with CDN mirror.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ script: https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js
         https://cdn.jsdelivr.net/chartist.js/latest/chartist.min.js
 
 link:   https://cdn.jsdelivr.net/chartist.js/latest/chartist.min.css
-        style.css
+        https://cdn.jsdelivr.net/gh/NFDI4Energy/EFZN_rdm@main/style.css
 -->
 
 # Research Data Management


### PR DESCRIPTION
Fixes the green number problem. 

However, it comes with the disadvantage, that because of the mirroring using the CDN the style.css will always be loaded from one specific branch (main).